### PR TITLE
Add catv1 .NET build artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Dependencies
-/node_modules
 /BAS/node_modules
 
 # Log files
@@ -16,6 +15,10 @@ pnpm-debug.log*
 # Production
 /dist
 /build
+
+# .NET build artifacts (catv1)
+catv1/bin/
+catv1/obj/
 
 # IDEs
 .vscode/


### PR DESCRIPTION
Add catv1/bin/ and catv1/obj/ to ignore .NET build outputs for the catv1 project. Also remove the top-level /node_modules entry while retaining /BAS/node_modules.