### PR TITLE
Remove OnLogoutClicked handler

### DIFF
--- a/catv1/Views/StudentHomePage.xaml.cs
+++ b/catv1/Views/StudentHomePage.xaml.cs
@@ -44,8 +44,5 @@ public partial class StudentHomePage : ContentPage
         await Shell.Current.GoToAsync("//student/studentHistoryTab/studentHistory");
     }
 
-    private async void OnLogoutClicked(object sender, EventArgs e)
-    {
-        await Shell.Current.GoToAsync("//login");
-    }
+
 }


### PR DESCRIPTION
Delete the private async OnLogoutClicked method from StudentHomePage.xaml.cs. Cleans up an unused logout click handler that navigated to the //login route, likely superseded or moved elsewhere.