### PR TITLE
Replace Path icons with MaterialIcons labels

### DIFF
--- a/catv1/Views/ScanPage.xaml
+++ b/catv1/Views/ScanPage.xaml
@@ -80,13 +80,7 @@
                         Stroke="{StaticResource GlassBorder}"
                         StrokeShape="RoundRectangle 16">
                             <Grid Padding="16,0" ColumnDefinitions="Auto, *">
-                                <Path
-                                    Data="M19,4H18V2H16V4H8V2H6V4H5C3.89,4 3,4.89 3,6V20A2,2 0 0,0 5,22H19A2,2 0 0,0 21,20V6C21,4.89 20.1,4 19,4M19,20H5V10H19V20M19,8H5V6H19V8Z"
-                                    Fill="{StaticResource Gray400}"
-                                    HorizontalOptions="Center"
-                                    VerticalOptions="Center"
-                                    WidthRequest="20"
-                                    HeightRequest="20" />
+                                <Label FontFamily="MaterialIcons" Text="&#xe916;" TextColor="{StaticResource Gray400}" FontSize="20" HorizontalOptions="Center" VerticalOptions="Center" />
                                 <DatePicker
                                     Grid.Column="1"
                                     Date="{Binding SelectedDate}"
@@ -132,13 +126,7 @@
                     <Border.GestureRecognizers>
                         <TapGestureRecognizer Command="{Binding BackCommand}" />
                     </Border.GestureRecognizers>
-                    <Path
-                                Data="M20,11V13H8L13.5,18.5L12.08,19.92L4.16,12L12.08,4.08L13.5,5.5L8,11H20Z"
-                                Fill="White"
-                                HorizontalOptions="Center"
-                                VerticalOptions="Center"
-                                WidthRequest="18"
-                                HeightRequest="18" />
+                    <Label FontFamily="MaterialIcons" Text="&#xe5c4;" TextColor="White" FontSize="18" HorizontalOptions="Center" VerticalOptions="Center" />
                 </Border>
 
                 <VerticalStackLayout Grid.Column="1" VerticalOptions="Center">
@@ -153,14 +141,7 @@
                         Text="{Binding DateDisplay}" />
                 </VerticalStackLayout>
 
-                <Path
-                    Grid.Column="2"
-                    Data="M12,15.5A3.5,3.5 0 0,1 8.5,12A3.5,3.5 0 0,1 12,8.5A3.5,3.5 0 0,1 15.5,12A3.5,3.5 0 0,1 12,15.5M19.43,12.97C19.47,12.65 19.5,12.33 19.5,12C19.5,11.67 19.47,11.34 19.43,11L21.54,9.37C21.73,9.22 21.78,8.95 21.66,8.73L19.66,5.27C19.54,5.05 19.27,4.96 19.05,5.05L16.56,6.05C16.04,5.66 15.5,5.32 14.87,5.07L14.5,2.42C14.46,2.18 14.25,2 14,2H10C9.75,2 9.54,2.18 9.5,2.42L9.13,5.07C8.5,5.32 7.96,5.66 7.44,6.05L4.95,5.05C4.73,4.96 4.46,5.05 4.34,5.27L2.34,8.73C2.21,8.95 2.27,9.22 2.46,9.37L4.57,11C4.53,11.34 4.5,11.67 4.5,12C4.5,12.33 4.53,12.65 4.57,12.97L2.46,14.63C2.27,14.78 2.21,15.05 2.34,15.27L4.34,18.73C4.46,18.95 4.73,19.03 4.95,18.95L7.44,17.94C7.96,18.34 8.5,18.68 9.13,18.93L9.5,21.58C9.54,21.82 9.75,22 10,22H14C14.25,22 14.46,21.82 14.5,21.58L14.87,18.93C15.5,18.68 16.04,18.34 16.56,17.94L19.05,18.95C19.27,19.03 19.54,18.95 19.66,18.73L21.66,15.27C21.78,15.05 21.73,14.78 21.54,14.63L19.43,12.97Z"
-                    Fill="{StaticResource Gray400}"
-                    HorizontalOptions="Center"
-                    VerticalOptions="Center"
-                    WidthRequest="22"
-                    HeightRequest="22" />
+                <Label FontFamily="MaterialIcons" Text="&#xe8b8;" TextColor="{StaticResource Gray400}" FontSize="22" HorizontalOptions="Center" VerticalOptions="Center" Grid.Column="2" />
             </Grid>
 
             <!--  Camera & Stats  -->
@@ -176,7 +157,7 @@
                         <Grid>
                             <zxing:CameraBarcodeReaderView
                                 x:Name="cameraBarcodeReaderView"
-                                BarcodesDetected="cameraBarcodeReaderView_BarcodesDetected"
+                                BarcodesDetected="CameraBarcodeReaderView_BarcodesDetected"
                                 IsDetecting="{Binding IsSessionActive}"
                                 IsTorchOn="False" />
 


### PR DESCRIPTION
Replace several inline Path vector icons in ScanPage.xaml with Label elements using the MaterialIcons font (keeps colors, sizes and alignment). This simplifies XAML and avoids embedding complex path data for the calendar, back arrow and settings icons. Also rename the barcode event handler attribute from "cameraBarcodeReaderView_BarcodesDetected" to "CameraBarcodeReaderView_BarcodesDetected" to match the updated handler name.