### PR TITLE
Manage camera permission and lifecycle

### DIFF
--- a/catv1/Views/ScanPage.xaml.cs
+++ b/catv1/Views/ScanPage.xaml.cs
@@ -17,7 +17,36 @@ public partial class ScanPage : ContentPage
         };
     }
 
-    private void cameraBarcodeReaderView_BarcodesDetected(object sender, BarcodeDetectionEventArgs e)
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+
+        // Request camera permission at runtime (required on Android 6+)
+        var status = await Permissions.RequestAsync<Permissions.Camera>();
+        if (status != PermissionStatus.Granted)
+        {
+            await DisplayAlertAsync("Camera Permission",
+                "Camera access is required to scan student IDs. Please grant the permission in Settings.",
+                "OK");
+            return;
+        }
+
+        // Resume camera if a session is already active (e.g. navigated away and back)
+        if (BindingContext is ScanViewModel vm && vm.IsSessionActive)
+        {
+            cameraBarcodeReaderView.IsDetecting = true;
+        }
+    }
+
+    protected override void OnDisappearing()
+    {
+        base.OnDisappearing();
+
+        // Pause the camera when leaving the page to release the hardware resource
+        cameraBarcodeReaderView.IsDetecting = false;
+    }
+
+    private void CameraBarcodeReaderView_BarcodesDetected(object sender, BarcodeDetectionEventArgs e)
     {
         if (BindingContext is ScanViewModel viewModel)
         {


### PR DESCRIPTION
Request camera permission at runtime in OnAppearing (required on Android 6+); show an alert if not granted and bail out. If the ScanViewModel indicates an active session, resume barcode detection by setting cameraBarcodeReaderView.IsDetecting = true. Override OnDisappearing to pause detection (IsDetecting = false) to release the camera hardware. Also adjust the barcode-detected handler name/casing to follow naming conventions.