### PR TITLE
Use theme resources and MaterialIcons in LoginPage

### DIFF
--- a/catv1/Views/LoginPage.xaml
+++ b/catv1/Views/LoginPage.xaml
@@ -5,7 +5,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:vm="clr-namespace:catv1.ViewModels"
     Title="Login"
-    BackgroundColor="#0F172A"
+    BackgroundColor="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Background}}"
     Shell.NavBarIsVisible="False">
 
 
@@ -49,20 +49,14 @@
                         Margin="0,40,0,0"
                         Spacing="10">
                         <Border
-                            BackgroundColor="#1E293B"
+                            BackgroundColor="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Surface}}"
                             HeightRequest="60"
                             HorizontalOptions="Center"
                             Stroke="#334155"
                             StrokeShape="RoundRectangle 30"
                             StrokeThickness="1"
                             WidthRequest="60">
-                            <Path
-                                Data="M12,3L1,9L12,15L21,10.09V17H23V9M5,13.18V17.18L12,21L19,17.18V13.18L12,17L5,13.18Z"
-                                Fill="#3B82F6"
-                                HorizontalOptions="Center"
-                                VerticalOptions="Center"
-                                WidthRequest="28"
-                                HeightRequest="28" />
+                            <Label FontFamily="MaterialIcons" Text="&#xe80c;" TextColor="#3B82F6" FontSize="28" HorizontalOptions="Center" VerticalOptions="Center" />
                         </Border>
                         <Label
                             FontAttributes="Bold"
@@ -99,7 +93,7 @@
                             <!--  Role Switcher  -->
                             <Border
                                 Padding="4"
-                                BackgroundColor="#0F172A"
+                                BackgroundColor="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Background}}"
                                 Stroke="Transparent"
                                 StrokeShape="RoundRectangle 10">
                                 <Grid ColumnDefinitions="*,*">
@@ -150,19 +144,13 @@
                                         Text="EMAIL ADDRESS"
                                         TextColor="#CBD5E1" />
                                     <Border
-                                        BackgroundColor="#0F172A"
+                                        BackgroundColor="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Background}}"
                                         HeightRequest="50"
                                         Stroke="#334155"
                                         StrokeShape="RoundRectangle 8"
                                         StrokeThickness="1">
                                         <Grid ColumnDefinitions="50, *">
-                                            <Path
-                                                Data="M20,8L12,13L4,8V6L12,11L20,6M20,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V6C22,4.89 21.1,4 20,4Z"
-                                                Fill="#64748B"
-                                                HorizontalOptions="Center"
-                                                VerticalOptions="Center"
-                                                WidthRequest="18"
-                                                HeightRequest="18" />
+                                            <Label FontFamily="MaterialIcons" Text="&#xe158;" TextColor="#64748B" FontSize="18" HorizontalOptions="Center" VerticalOptions="Center" />
                                             <Entry
                                                 Grid.Column="1"
                                                 Margin="0,0,10,0"
@@ -185,19 +173,13 @@
                                         Text="PASSWORD"
                                         TextColor="#CBD5E1" />
                                     <Border
-                                        BackgroundColor="#0F172A"
+                                        BackgroundColor="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Background}}"
                                         HeightRequest="50"
                                         Stroke="#334155"
                                         StrokeShape="RoundRectangle 8"
                                         StrokeThickness="1">
                                         <Grid ColumnDefinitions="50, *, 50">
-                                            <Path
-                                                Data="M12,17A2,2 0 0,0 14,15C14,13.89 13.1,13 12,13A2,2 0 0,0 10,15A2,2 0 0,0 12,17M18,8A2,2 0 0,1 20,10V20A2,2 0 0,1 18,22H6A2,2 0 0,1 4,20V10C4,8.89 4.9,8 6,8H7V6A5,5 0 0,1 12,1A5,5 0 0,1 17,6V8H18M12,3A3,3 0 0,0 9,6V8H15V6A3,3 0 0,0 12,3Z"
-                                                Fill="#64748B"
-                                                HorizontalOptions="Center"
-                                                VerticalOptions="Center"
-                                                WidthRequest="18"
-                                                HeightRequest="18" />
+                                            <Label FontFamily="MaterialIcons" Text="&#xe897;" TextColor="#64748B" FontSize="18" HorizontalOptions="Center" VerticalOptions="Center" />
                                             <Entry
                                                 x:Name="EntryPassword"
                                                 Grid.Column="1"
@@ -212,17 +194,12 @@
                                                 Grid.Column="2"
                                                 BackgroundColor="Transparent"
                                                 HeightRequest="40"
-                                                WidthRequest="40">
+                                                WidthRequest="40"
+                                                StrokeThickness="0">
                                                 <Border.GestureRecognizers>
                                                     <TapGestureRecognizer Command="{Binding TogglePasswordCommand}" />
                                                 </Border.GestureRecognizers>
-                                                <Path
-                                                    Data="M12,9A3,3 0 0,0 9,12A3,3 0 0,0 12,15A3,3 0 0,0 15,12A3,3 0 0,0 12,9M12,17A5,5 0 0,1 7,12A5,5 0 0,1 12,7A5,5 0 0,1 17,12A5,5 0 0,1 12,17M12,4.5C7,4.5 2.73,7.61 1,12C2.73,16.39 7,19.5 12,19.5C17,19.5 21.27,16.39 23,12C21.27,7.61 17,4.5 12,4.5Z"
-                                                    Fill="#64748B"
-                                                    HorizontalOptions="Center"
-                                                    VerticalOptions="Center"
-                                                    WidthRequest="18"
-                                                    HeightRequest="18" />
+                                                <Label FontFamily="MaterialIcons" Text="&#xe8f4;" TextColor="#64748B" FontSize="18" HorizontalOptions="Center" VerticalOptions="Center" />
                                             </Border>
                                         </Grid>
                                     </Border>
@@ -237,7 +214,7 @@
                                     </HorizontalStackLayout.GestureRecognizers>
                                     <!--  Custom Checkbox Look  -->
                                     <Border
-                                        BackgroundColor="#0F172A"
+                                        BackgroundColor="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Background}}"
                                         HeightRequest="20"
                                         Stroke="#3B82F6"
                                         StrokeShape="RoundRectangle 4"


### PR DESCRIPTION
Replace hardcoded hex colors with AppThemeBinding + StaticResource to support light/dark themes across the LoginPage. Swap Path vector icons for Label elements using the MaterialIcons font for simpler, consistent icon rendering. Tweak Border properties (e.g. set StrokeThickness=0 on the password toggle) and add a trailing newline. These changes improve theming, readability, and maintainability of the XAML.