### PR TITLE
Call CheckAutoLoginAsync when page appears

### DIFF
--- a/catv1/Views/LoginPage.xaml.cs
+++ b/catv1/Views/LoginPage.xaml.cs
@@ -9,4 +9,13 @@ public partial class LoginPage : ContentPage
         InitializeComponent();
         BindingContext = viewModel;
     }
+
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+        if (BindingContext is LoginViewModel vm)
+        {
+            await vm.CheckAutoLoginAsync();
+        }
+    }
 }


### PR DESCRIPTION
Add an override of OnAppearing in LoginPage to call CheckAutoLoginAsync on the LoginViewModel (if BindingContext matches). Ensures the view model's auto-login check runs whenever the login page becomes visible while still calling base.OnAppearing().