### PR TITLE
Use MaterialIcons label for back arrow

### DIFF
--- a/catv1/Views/BarcodePage.xaml
+++ b/catv1/Views/BarcodePage.xaml
@@ -31,13 +31,7 @@
                     <Border.GestureRecognizers>
                         <TapGestureRecognizer Tapped="OnBackClicked" />
                     </Border.GestureRecognizers>
-                    <Path
-                        Data="M20,11V13H8L13.5,18.5L12.08,19.92L4.16,12L12.08,4.08L13.5,5.5L8,11H20Z"
-                        Fill="White"
-                        HorizontalOptions="Center"
-                        VerticalOptions="Center"
-                        WidthRequest="18"
-                        HeightRequest="18" />
+                    <Label FontFamily="MaterialIcons" Text="&#xe5c4;" TextColor="White" FontSize="18" HorizontalOptions="Center" VerticalOptions="Center" />
                 </Border>
                 <Label
                     Grid.Column="1"


### PR DESCRIPTION
Replace the SVG Path used for the back arrow with a Label that renders the MaterialIcons glyph (&#xe5c4;). This simplifies the XAML, relies on the icon font for consistent sizing/color, and reduces markup by removing explicit Path properties.