### PR TITLE
Remove background overlay image from ScanPage

### DIFF
--- a/catv1/Views/ScanPage.xaml
+++ b/catv1/Views/ScanPage.xaml
@@ -15,11 +15,6 @@
     </ContentPage.Resources>
 
     <Grid>
-        <!--  Background Overlay for consistency (optional, camera might cover it)  -->
-        <Image
-            Aspect="AspectFill"
-            Opacity="0.1"
-            Source="Resources/Images/lecture_room.png" />
         <Grid
             Padding="30"
             IsVisible="{Binding IsSetupVisible}"


### PR DESCRIPTION
Delete the low-opacity lecture_room Image element from ScanPage.xaml. The overlay was optional and could be covered by the camera; removing it simplifies the layout and avoids an unnecessary image resource.